### PR TITLE
Fix order of concatenating Javascript files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,12 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 
-var sources = ['src/**/*.js',
-    "node_modules/videojs-contrib-media-sources/dist/videojs-contrib-media-sources.min.js",
-    "node_modules/videojs-contrib-hls/dist/videojs-contrib-hls.min.js",
-    "node_modules/hls.js/dist/hls.min.js"];
+var sources = [
+    'node_modules/videojs-contrib-media-sources/dist/videojs-contrib-media-sources.min.js',
+    'node_modules/videojs-contrib-hls/dist/videojs-contrib-hls.min.js',
+    'node_modules/hls.js/dist/hls.min.js',
+    'src/**/*.js'
+];
 
 gulp.task('build', function() {
     return gulp.src(sources)


### PR DESCRIPTION
The current configurations tries to execute this plugin before loading all dependencies.