### PR TITLE
Add the ability to skip hls.js on a per source basis.

### DIFF
--- a/src/videojs5.hlsjs.js
+++ b/src/videojs5.hlsjs.js
@@ -104,7 +104,9 @@
             var hlsTypeRE = /^application\/x-mpegURL$/i;
             var hlsExtRE = /\.m3u8/i;
 
-            if (hlsTypeRE.test(source.type)) {
+            if (source.skipContribHlsJs) {
+                return '';
+            } else if (hlsTypeRE.test(source.type)) {
                 return 'probably';
             } else if (hlsExtRE.test(source.src)) {
                 return 'maybe';


### PR DESCRIPTION
I've got a website where I want to use `hls.js` for some content cross platform. However other content requires DRM and so needs to use native HLS in Safari. This option allows me to add an option to the source object passed to video.js that lets me skip this source handler.