### PR TITLE
missing ./ in main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "videojs-contrib-hls.js",
   "version": "2.0.1",
   "description": "hls.js plugin for videojs",
-  "main": "/dist/videojs-contrib-hlsjs.js",
+  "main": "./dist/videojs-contrib-hlsjs.js",
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
fixed browserify issue: "Cannot find module 'videojs-contrib-hls.js'"
as reference video.js uses main: "./es5/video.js"