### PR TITLE
Fix caption integration

### DIFF
--- a/src/videojs5.hlsjs.js
+++ b/src/videojs5.hlsjs.js
@@ -101,6 +101,18 @@
             });
         });
 
+        // Intercept native TextTrack calls and route to video.js directly only
+        // if native text tracks are not supported on this browser.
+        if (!tech.featuresNativeTextTracks) {
+            Object.defineProperty(el, 'textTracks', {
+                value: tech.textTracks,
+                writable: false
+            });
+            el.addTextTrack = function() {
+                return tech.addTextTrack(arguments);
+            }
+        }
+
         // attach hlsjs to videotag
         hls.attachMedia(el);
         hls.loadSource(source.src);


### PR DESCRIPTION
This may be a little hacky, but it does fix in-band caption integration on versions of video.js > 5.13.0. 

Related to https://github.com/Peer5/videojs-contrib-hls.js/issues/17