### PR TITLE
Change the index of this source handler

### DIFF
--- a/src/videojs.hlsjs.js
+++ b/src/videojs.hlsjs.js
@@ -162,7 +162,7 @@ if (Hls.isSupported()) {
     html5Tech = html5Tech || (videojs.getComponent && videojs.getComponent('Html5')); // videojs5
 
     if (html5Tech) {
-      html5Tech.registerSourceHandler(HlsSourceHandler, 0);
+      html5Tech.registerSourceHandler(HlsSourceHandler);
     }
   }
   else {


### PR DESCRIPTION
This source handler should not be place at the 0 index since the videojs has H5 native handler. We should judge if the native handler can handle the source firstly.